### PR TITLE
feat: add macOS runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,16 @@
 - 可访问的 IndexTTS 2.5 服务（Gradio 或 FastAPI）
 - OpenLux API Key，并有文本模型与图片模型的调用权限
 
-先确认音视频依赖可用：
+先确认音视频依赖可用。
+
+macOS/Linux：
+
+```bash
+ffmpeg -version
+ffprobe -version
+```
+
+Windows PowerShell：
 
 ```powershell
 ffmpeg -version
@@ -168,6 +177,21 @@ PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple .venv/bin/python -m pip i
 
 ## 开发验证
 
+### macOS/Linux
+
+```bash
+# 前端构建与页面验证
+(cd web && npm test)
+
+# 后端任务队列、断点恢复与时间线测试
+.venv/bin/python -m unittest discover -s tests -v
+
+# Remotion 类型检查
+(cd video_renderer && npm run build)
+```
+
+### Windows PowerShell
+
 ```powershell
 # 前端构建与页面验证
 Push-Location web
@@ -176,6 +200,11 @@ Pop-Location
 
 # 后端任务队列、断点恢复与时间线测试
 .\.venv\Scripts\python.exe -m unittest discover -s tests -v
+
+# Remotion 类型检查
+Push-Location video_renderer
+npm run build
+Pop-Location
 ```
 
 ## 项目结构

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@
 
 ### 环境要求
 
-- Windows 10/11（已提供一键启动脚本）
+- Windows 10/11（提供 PowerShell 一键启动脚本）
+- macOS 15+（Intel 与 Apple Silicon，提供 shell 一键启动脚本；Remotion 视频渲染要求）
 - Python 3.11+
 - Node.js 22.13+
 - FFmpeg 与 FFprobe，且已加入系统 `PATH`
@@ -95,6 +96,37 @@ Pop-Location
 ```
 
 脚本会启动前后端并打开 [http://127.0.0.1:13000/](http://127.0.0.1:13000/)。同一局域网设备也可以通过脚本输出的地址访问。
+
+### macOS
+
+先安装 Python 3.11+、Node.js 22.13+、FFmpeg 与 FFprobe。使用 Homebrew 时可以执行：
+
+```bash
+brew install python@3.13 node ffmpeg
+```
+
+在项目根目录执行一次安装：
+
+```bash
+python3.13 scripts/prepare_env.py
+.venv/bin/python -m pip install -r webapp/requirements.txt
+(cd web && npm ci)
+```
+
+国内网络安装 Python 依赖较慢时，可以只对当前命令使用清华 PyPI 镜像：
+
+```bash
+PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple python3.13 scripts/prepare_env.py
+PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple .venv/bin/python -m pip install -r webapp/requirements.txt
+```
+
+然后启动工作台：
+
+```bash
+./start-webapp.sh
+```
+
+脚本会启动前后端并打开 [http://127.0.0.1:13000/](http://127.0.0.1:13000/)。如果系统没有自动打开浏览器，也可以手动访问该地址。动态信息图首次运行时会按当前平台准备 Remotion 与 Whisper.cpp 所需资源。macOS 14 及更低版本可以启动界面和 API，但当前 Remotion 版本的视频渲染不保证成功。
 
 ### 首次配置
 
@@ -157,7 +189,8 @@ Pop-Location
 ├── video_renderer/       # Remotion 动态信息图渲染器
 ├── web/                  # React 前端
 ├── webapp/               # FastAPI 后端
-└── start-webapp.ps1      # Windows 一键启动
+├── start-webapp.ps1      # Windows 一键启动
+└── start-webapp.sh       # macOS/Linux 一键启动
 ```
 
 ## 贡献

--- a/scripts/add_key_text.py
+++ b/scripts/add_key_text.py
@@ -13,7 +13,9 @@ FONT_CANDIDATES = (
     Path("C:/Windows/Fonts/msyh.ttc"),
     Path("C:/Windows/Fonts/simhei.ttf"),
     Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc"),
+    Path("/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc"),
     Path("/System/Library/Fonts/PingFang.ttc"),
+    Path("/System/Library/Fonts/STHeiti Medium.ttc"),
 )
 
 

--- a/scripts/render_annotation_preview.py
+++ b/scripts/render_annotation_preview.py
@@ -5,13 +5,27 @@ from pathlib import Path
 from PIL import Image, ImageDraw, ImageFont
 
 
+FONT_CANDIDATES = (
+    Path("C:/Windows/Fonts/msyh.ttc"),
+    Path("C:/Windows/Fonts/simhei.ttf"),
+    Path("/System/Library/Fonts/PingFang.ttc"),
+    Path("/System/Library/Fonts/STHeiti Medium.ttc"),
+    Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"),
+    Path("/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc"),
+)
+
+
+def font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    path = next((candidate for candidate in FONT_CANDIDATES if candidate.exists()), None)
+    return ImageFont.truetype(str(path), size) if path else ImageFont.load_default()
+
+
 def main(image_path: str, annotation_path: str, output_path: str) -> None:
     image = Image.open(image_path).convert("RGBA")
     overlay = Image.new("RGBA", image.size, (0, 0, 0, 0))
     draw = ImageDraw.Draw(overlay)
-    font_file = "C:/Windows/Fonts/msyh.ttc"
-    font = ImageFont.truetype(font_file, 28)
-    small_font = ImageFont.truetype(font_file, 18)
+    label_font = font(28)
+    small_font = font(18)
     colors = [(38, 103, 255, 225), (255, 105, 92, 225), (41, 167, 102, 225), (181, 100, 255, 225)]
 
     data = json.loads(Path(annotation_path).read_text(encoding="utf-8"))
@@ -26,7 +40,7 @@ def main(image_path: str, annotation_path: str, output_path: str) -> None:
         draw.text((x + 19, y + 8), str(index), anchor="ma", font=small_font, fill="white")
         label = f"{index}. {element['label']}  {element['reveal']['direction']}"
         draw.rounded_rectangle((x + 52, y + 8, min(right - 8, x + 52 + len(label) * 19), y + 46), radius=6, fill=(255, 255, 255, 225))
-        draw.text((x + 60, y + 12), label, font=small_font, fill=color)
+        draw.text((x + 60, y + 12), label, font=label_font, fill=color)
         start = tuple(element["handPath"]["start"])
         end = tuple(element["handPath"]["end"])
         draw.line((start, end), fill=color, width=4)

--- a/scripts/render_infographic.py
+++ b/scripts/render_infographic.py
@@ -12,17 +12,27 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageEnhance, ImageFilter, ImageFont
 
 W, H, FPS = 1920, 1080, 30
+FONT_DIRS = (
+    Path("C:/Windows/Fonts"),
+    Path("/System/Library/Fonts"),
+    Path("/usr/share/fonts/opentype/noto"),
+    Path("/usr/share/fonts/truetype/noto"),
+)
 
 
 def font(size: int, serif: bool = False, bold: bool = False) -> ImageFont.FreeTypeFont:
-    root = Path("C:/Windows/Fonts")
-    names = (["simhei.ttf", "msyhbd.ttc"] if bold else
-             ["simkai.ttf", "simsun.ttc"] if serif else
-             ["msyh.ttc", "simhei.ttf"])
-    for name in names:
-        path = root / name
-        if path.exists():
-            return ImageFont.truetype(str(path), size=size)
+    names = (
+        ["simhei.ttf", "msyhbd.ttc", "PingFang.ttc", "STHeiti Medium.ttc", "NotoSansCJK-Bold.ttc"]
+        if bold
+        else ["simkai.ttf", "simsun.ttc", "PingFang.ttc", "Hiragino Sans GB.ttc", "NotoSansCJK-Regular.ttc"]
+        if serif
+        else ["msyh.ttc", "simhei.ttf", "PingFang.ttc", "STHeiti Medium.ttc", "NotoSansCJK-Regular.ttc"]
+    )
+    for directory in FONT_DIRS:
+        for name in names:
+            path = directory / name
+            if path.exists():
+                return ImageFont.truetype(str(path), size=size)
     return ImageFont.load_default()
 
 

--- a/start-webapp.sh
+++ b/start-webapp.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON="$ROOT/.venv/bin/python"
+WEB_ROOT="$ROOT/web"
+STATE_DIR="$ROOT/.webapp"
+BACKEND_OUTPUT_LOG="$STATE_DIR/backend-output.log"
+BACKEND_ERROR_LOG="$STATE_DIR/backend-error.log"
+FRONTEND_OUTPUT_LOG="$STATE_DIR/frontend-output.log"
+FRONTEND_ERROR_LOG="$STATE_DIR/frontend-error.log"
+
+if [[ ! -x "$PYTHON" ]]; then
+  printf 'Python environment not found: %s\n' "$PYTHON" >&2
+  printf 'Run: python3.13 scripts/prepare_env.py\n' >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  printf 'Node.js/npm not found. Install Node.js 22.13+ first.\n' >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  printf 'curl not found. Install curl before starting the app.\n' >&2
+  exit 1
+fi
+
+mkdir -p "$STATE_DIR"
+
+backend_ready() {
+  curl -fsS --max-time 2 http://127.0.0.1:18765/api/health >/dev/null 2>&1
+}
+
+frontend_ready() {
+  curl -fsS --max-time 2 http://127.0.0.1:13000 >/dev/null 2>&1
+}
+
+if ! backend_ready; then
+  : > "$BACKEND_OUTPUT_LOG"
+  : > "$BACKEND_ERROR_LOG"
+  (cd "$ROOT" && nohup "$PYTHON" -m uvicorn webapp.server:app --host 127.0.0.1 --port 18765 >"$BACKEND_OUTPUT_LOG" 2>"$BACKEND_ERROR_LOG" & echo $! > "$STATE_DIR/backend.pid")
+fi
+
+if ! frontend_ready; then
+  : > "$FRONTEND_OUTPUT_LOG"
+  : > "$FRONTEND_ERROR_LOG"
+  (cd "$WEB_ROOT" && nohup npm run dev >"$FRONTEND_OUTPUT_LOG" 2>"$FRONTEND_ERROR_LOG" & echo $! > "$STATE_DIR/frontend.pid")
+fi
+
+backend_ok=false
+frontend_ok=false
+for _ in {1..90}; do
+  backend_ready && backend_ok=true
+  frontend_ready && frontend_ok=true
+  if [[ "$backend_ok" == true && "$frontend_ok" == true ]]; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$backend_ok" != true ]]; then
+  printf 'Backend failed to start. See %s\n' "$BACKEND_ERROR_LOG" >&2
+  exit 1
+fi
+
+if [[ "$frontend_ok" != true ]]; then
+  printf 'Frontend failed to start. See %s\n' "$FRONTEND_ERROR_LOG" >&2
+  exit 1
+fi
+
+printf 'Ready: http://127.0.0.1:13000\n'
+if command -v open >/dev/null 2>&1; then
+  open http://127.0.0.1:13000 >/dev/null 2>&1 || true
+fi

--- a/video_renderer/README.md
+++ b/video_renderer/README.md
@@ -6,7 +6,9 @@
 
 清单页的 `relationshipType` 为 `none`，不会绘制箭头。只有原文明确表达步骤或因果关系时，渲染器才允许显示方向连接。
 
-首次运行会下载 Windows Whisper.cpp 1.5.5 二进制和 multilingual `medium` 模型。严格中文旁白对齐优先保证准确率；资源受限时可通过 `INFOGRAPHIC_WHISPER_MODEL=small` 改用较小模型。
+首次运行会通过 Remotion 安装器准备当前平台对应的 Whisper.cpp 1.5.5 二进制和 multilingual `medium` 模型。严格中文旁白对齐优先保证准确率；资源受限时可通过 `INFOGRAPHIC_WHISPER_MODEL=small` 改用较小模型。
+
+项目当前固定使用 Remotion 4.0.515。macOS 15 及更高版本适合运行当前 Remotion 视频渲染链；若后续升级 Remotion，请重新验证 macOS 视频渲染。
 
 安装与检查：
 

--- a/video_renderer/render.mjs
+++ b/video_renderer/render.mjs
@@ -3,19 +3,35 @@ import path from 'node:path';
 import process from 'node:process';
 import {bundle} from '@remotion/bundler';
 import {renderMedia, selectComposition} from '@remotion/renderer';
+import {fileURLToPath} from 'node:url';
 
 const [propsPath, outputPath, publicDir] = process.argv.slice(2);
 if (!propsPath || !outputPath || !publicDir) {
   throw new Error('用法：node render.mjs <props.json> <output.mp4> <job-public-dir>');
 }
 
-const rendererRoot = path.dirname(new URL(import.meta.url).pathname.replace(/^\/(.:)/, '$1'));
+const rendererRoot = path.dirname(fileURLToPath(import.meta.url));
 const inputProps = JSON.parse(fs.readFileSync(propsPath, 'utf8'));
+const platformBrowserCandidates = process.platform === 'darwin'
+  ? [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    ]
+  : process.platform === 'win32'
+    ? [
+        'C:/Program Files/Google/Chrome/Application/chrome.exe',
+        'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
+        'C:/Program Files/Microsoft/Edge/Application/msedge.exe',
+      ]
+    : [
+        '/usr/bin/google-chrome',
+        '/usr/bin/chromium',
+        '/usr/bin/chromium-browser',
+      ];
 const browserCandidates = [
   process.env.REMOTION_BROWSER_EXECUTABLE,
-  'C:/Program Files/Google/Chrome/Application/chrome.exe',
-  'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
-  'C:/Program Files/Microsoft/Edge/Application/msedge.exe',
+  ...(process.env.REMOTION_USE_SYSTEM_BROWSER === '0' ? [] : platformBrowserCandidates),
 ].filter(Boolean);
 const browserExecutable = browserCandidates.find((candidate) => fs.existsSync(candidate));
 

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -9,6 +9,7 @@ import queue
 import re
 import shutil
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -27,12 +28,16 @@ STATE_DIR = ROOT / ".webapp"
 JOBS_DIR = STATE_DIR / "jobs"
 CONFIG_PATH = STATE_DIR / "config.json"
 PREFERENCES_PATH = STATE_DIR / "preferences.json"
-PYTHON = ROOT / ".venv" / "Scripts" / "python.exe"
+PYTHON = Path(sys.executable)
 NODE = shutil.which("node") or "node"
 REMOTION_RENDERER = ROOT / "video_renderer"
 HAND = ROOT / "assets" / "drawing-hand-clean.png"
 PIPELINE_VERSION = "narrated_deck_v8_oil_visual"
 ALIGNMENT_SEGMENTATION = "word-boundary-dtw-audio-v2"
+SUBTITLE_FONT = os.environ.get(
+    "CS_BOARD_SUBTITLE_FONT",
+    "PingFang SC" if sys.platform == "darwin" else "Microsoft YaHei",
+)
 
 DEFAULT_CONFIG = {
     "api_key": "",
@@ -1410,7 +1415,15 @@ def make_branded_hand(text: str, target: Path) -> Path:
         return HAND
     hand = Image.open(HAND).convert("RGBA")
     label = text.strip()[:12]
-    font_paths = [Path("C:/Windows/Fonts/msyhbd.ttc"), Path("C:/Windows/Fonts/msyh.ttc"), Path("C:/Windows/Fonts/simhei.ttf")]
+    font_paths = [
+        Path("C:/Windows/Fonts/msyhbd.ttc"),
+        Path("C:/Windows/Fonts/msyh.ttc"),
+        Path("C:/Windows/Fonts/simhei.ttf"),
+        Path("/System/Library/Fonts/PingFang.ttc"),
+        Path("/System/Library/Fonts/STHeiti Medium.ttc"),
+        Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc"),
+        Path("/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc"),
+    ]
     font_path = next((p for p in font_paths if p.exists()), None)
     font = ImageFont.truetype(str(font_path), 58) if font_path else ImageFont.load_default()
     strip = Image.new("RGBA", (430, 104), (0, 0, 0, 0))
@@ -1801,7 +1814,7 @@ def render_generated_job(job_id: str, scenes: list[dict[str, Any]], boards: list
             if include_subtitles:
                 subtitles = job_dir / "subtitles.srt"
                 write_subtitles(scenes, subtitles)
-                subtitle_filter = "subtitles=subtitles.srt:force_style='FontName=Microsoft YaHei,FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00202020,BorderStyle=1,Outline=2,Shadow=0,MarginV=28,Alignment=2'"
+                subtitle_filter = f"subtitles=subtitles.srt:force_style='FontName={SUBTITLE_FONT},FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00202020,BorderStyle=1,Outline=2,Shadow=0,MarginV=28,Alignment=2'"
                 ffmpeg_command.extend(["-vf", subtitle_filter])
             ffmpeg_command.extend(["-c:v", "libx264", "-preset", "medium", "-crf", "19", "-pix_fmt", "yuv420p", "-c:a", "aac", "-b:a", "160k", "-movflags", "+faststart", "-shortest", partial_final.name])
             run(ffmpeg_command, cwd=job_dir, job_id=job_id)
@@ -1871,7 +1884,7 @@ def rerender_job(job_id: str, scenes_per_image: int, pen_text: str, include_key_
             if include_subtitles:
                 subtitles = job_dir / "subtitles.srt"
                 write_subtitles(scenes, subtitles)
-                subtitle_filter = "subtitles=subtitles.srt:force_style='FontName=Microsoft YaHei,FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00202020,BorderStyle=1,Outline=2,Shadow=0,MarginV=28,Alignment=2'"
+                subtitle_filter = f"subtitles=subtitles.srt:force_style='FontName={SUBTITLE_FONT},FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00202020,BorderStyle=1,Outline=2,Shadow=0,MarginV=28,Alignment=2'"
                 ffmpeg_command.extend(["-vf", subtitle_filter])
             ffmpeg_command.extend(["-c:v", "libx264", "-preset", "medium", "-crf", "19", "-pix_fmt", "yuv420p", "-c:a", "aac", "-b:a", "160k", "-movflags", "+faststart", "-shortest", partial_final.name])
             run(ffmpeg_command, cwd=job_dir, job_id=job_id)

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -1285,8 +1285,8 @@ def _synthesize_voice_once(config: dict[str, Any], reference: Path, copy: str, t
     # default Gradio HTTP read timeout is too short and abandons a healthy job.
     client = Client(config["tts_url"], verbose=False, httpx_kwargs={"timeout": 1800.0})
     job = client.submit(
-        "与参考音频的音色相同", handle_file(str(reference)), copy, None, 0.65,
-        0, 0, 0, 0, 0, 0, 0, 0, "", False, 120,
+        "Same as the voice reference", handle_file(str(reference)), copy, "ZH", None, 0.65,
+        0, 0, 0, 0, 0, 0, 0, 0, "", False, 120, 1.0,
         True, 0.8, 30, 0.8, 0.0, 3, 10.0, 1500,
         api_name="/gen_single",
     )
@@ -1494,6 +1494,138 @@ def write_subtitles(scenes: list[dict[str, Any]], target: Path) -> None:
     for i, (start, end, text) in enumerate(cues, 1):
         lines.extend([str(i), f"{_srt_time(start)} --> {_srt_time(end)}", text, ""])
     target.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _ffmpeg_has_filter(filter_name: str) -> bool:
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return False
+    try:
+        result = subprocess.run(
+            [ffmpeg, "-hide_banner", "-filters"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return bool(re.search(rf"(?m)^\s*\S+\s+{re.escape(filter_name)}(?:\s|$)", result.stdout + result.stderr))
+
+
+def _parse_srt_time(value: str) -> int:
+    match = re.fullmatch(r"(\d+):(\d{2}):(\d{2})[,.](\d{3})", value.strip())
+    if not match:
+        raise ValueError(f"无法解析字幕时间：{value}")
+    hours, minutes, seconds, milliseconds = (int(part) for part in match.groups())
+    return ((hours * 60 + minutes) * 60 + seconds) * 1000 + milliseconds
+
+
+def _read_srt_cues(source: Path) -> list[tuple[int, int, str]]:
+    cues: list[tuple[int, int, str]] = []
+    blocks = re.split(r"\r?\n\s*\r?\n", source.read_text(encoding="utf-8-sig"))
+    for block in blocks:
+        lines = [line.rstrip() for line in block.splitlines()]
+        time_index = next((index for index, line in enumerate(lines) if "-->" in line), None)
+        if time_index is None:
+            continue
+        start_text, end_text = (part.strip() for part in lines[time_index].split("-->", 1))
+        text = "\n".join(line for line in lines[time_index + 1:] if line).strip()
+        if text:
+            cues.append((_parse_srt_time(start_text), _parse_srt_time(end_text), text))
+    return cues
+
+
+def _subtitle_font_path() -> Path | None:
+    candidates = [
+        Path("/System/Library/Fonts/PingFang.ttc"),
+        Path("/System/Library/Fonts/STHeiti Medium.ttc"),
+        Path("/System/Library/Fonts/Supplemental/Songti.ttc"),
+        Path("C:/Windows/Fonts/msyh.ttc"),
+        Path("C:/Windows/Fonts/simhei.ttf"),
+        Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"),
+        Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc"),
+        Path("/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc"),
+    ]
+    return next((path for path in candidates if path.exists()), None)
+
+
+def _render_subtitles_with_pillow(video: Path, subtitles: Path, target: Path, job_id: str | None = None) -> None:
+    import cv2
+    import numpy as np
+    from PIL import Image, ImageDraw, ImageFont
+
+    cues = _read_srt_cues(subtitles)
+    capture = cv2.VideoCapture(str(video))
+    if not capture.isOpened():
+        raise RuntimeError(f"无法读取字幕视频：{video.name}")
+    fps = capture.get(cv2.CAP_PROP_FPS) or 30.0
+    width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    writer = cv2.VideoWriter(
+        str(target),
+        cv2.VideoWriter_fourcc(*"mp4v"),
+        fps,
+        (width, height),
+    )
+    if not writer.isOpened():
+        capture.release()
+        raise RuntimeError("无法创建字幕视频")
+    font_path = _subtitle_font_path()
+    font_size = max(24, round(height * 20 / 1080))
+    font = ImageFont.truetype(str(font_path), font_size) if font_path else ImageFont.load_default()
+    stroke_width = max(2, round(font_size / 10))
+    cue_index = 0
+    frame_index = 0
+    try:
+        while True:
+            success, frame = capture.read()
+            if not success:
+                break
+            timestamp_ms = round(frame_index * 1000 / fps)
+            while cue_index < len(cues) and timestamp_ms >= cues[cue_index][1]:
+                cue_index += 1
+            if cue_index < len(cues) and cues[cue_index][0] <= timestamp_ms < cues[cue_index][1]:
+                text = cues[cue_index][2]
+                image = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+                draw = ImageDraw.Draw(image)
+                box = draw.multiline_textbbox((0, 0), text, font=font, stroke_width=stroke_width, spacing=4)
+                text_width = box[2] - box[0]
+                text_height = box[3] - box[1]
+                x = (width - text_width) / 2 - box[0]
+                y = height - max(28, round(height * 28 / 1080)) - text_height - box[1]
+                draw.multiline_text(
+                    (x, y),
+                    text,
+                    font=font,
+                    fill=(255, 255, 255),
+                    stroke_width=stroke_width,
+                    stroke_fill=(32, 32, 32),
+                    spacing=4,
+                    align="center",
+                )
+                frame = cv2.cvtColor(np.asarray(image), cv2.COLOR_RGB2BGR)
+            writer.write(frame)
+            frame_index += 1
+            if job_id and frame_index % 30 == 0:
+                ensure_job_active(job_id)
+    finally:
+        capture.release()
+        writer.release()
+
+
+def _subtitle_video_input(video: Path, subtitles: Path, fallback_target: Path, job_id: str | None = None) -> tuple[Path, str | None]:
+    if _ffmpeg_has_filter("subtitles"):
+        style = (
+            f"FontName={SUBTITLE_FONT},FontSize=20,PrimaryColour=&H00FFFFFF,"
+            "OutlineColour=&H00202020,BorderStyle=1,Outline=2,Shadow=0,MarginV=28,Alignment=2"
+        )
+        return video, f"subtitles=filename='{subtitles.name}':force_style='{style}'"
+    fallback_target.unlink(missing_ok=True)
+    _render_subtitles_with_pillow(video, subtitles, fallback_target, job_id)
+    return fallback_target, None
 
 
 def remotion_infographic_props(scenes: list[dict[str, Any]], style: str, duration_ms: int, subtitles_enabled: bool = False) -> dict[str, Any]:
@@ -1810,11 +1942,19 @@ def render_generated_job(job_id: str, scenes: list[dict[str, Any]], boards: list
         if not valid_media_file(final):
             partial_final = job_dir / f"{final.stem}.partial.mp4"
             partial_final.unlink(missing_ok=True)
-            ffmpeg_command = ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", silent.name, "-i", "voice.wav", "-map", "0:v:0", "-map", "1:a:0"]
+            video_input = silent
+            subtitle_filter = None
             if include_subtitles:
                 subtitles = job_dir / "subtitles.srt"
                 write_subtitles(scenes, subtitles)
-                subtitle_filter = f"subtitles=subtitles.srt:force_style='FontName={SUBTITLE_FONT},FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00202020,BorderStyle=1,Outline=2,Shadow=0,MarginV=28,Alignment=2'"
+                video_input, subtitle_filter = _subtitle_video_input(
+                    silent,
+                    subtitles,
+                    job_dir / f"{final.stem}.subtitles.mp4",
+                    job_id,
+                )
+            ffmpeg_command = ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", video_input.name, "-i", "voice.wav", "-map", "0:v:0", "-map", "1:a:0"]
+            if subtitle_filter:
                 ffmpeg_command.extend(["-vf", subtitle_filter])
             ffmpeg_command.extend(["-c:v", "libx264", "-preset", "medium", "-crf", "19", "-pix_fmt", "yuv420p", "-c:a", "aac", "-b:a", "160k", "-movflags", "+faststart", "-shortest", partial_final.name])
             run(ffmpeg_command, cwd=job_dir, job_id=job_id)
@@ -1880,11 +2020,19 @@ def rerender_job(job_id: str, scenes_per_image: int, pen_text: str, include_key_
         if not valid_media_file(final):
             partial_final = job_dir / "final.partial.mp4"
             partial_final.unlink(missing_ok=True)
-            ffmpeg_command = ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", "silent.mp4", "-i", "voice.wav", "-map", "0:v:0", "-map", "1:a:0"]
+            video_input = job_dir / "silent.mp4"
+            subtitle_filter = None
             if include_subtitles:
                 subtitles = job_dir / "subtitles.srt"
                 write_subtitles(scenes, subtitles)
-                subtitle_filter = f"subtitles=subtitles.srt:force_style='FontName={SUBTITLE_FONT},FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00202020,BorderStyle=1,Outline=2,Shadow=0,MarginV=28,Alignment=2'"
+                video_input, subtitle_filter = _subtitle_video_input(
+                    video_input,
+                    subtitles,
+                    job_dir / "final.subtitles.mp4",
+                    job_id,
+                )
+            ffmpeg_command = ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", video_input.name, "-i", "voice.wav", "-map", "0:v:0", "-map", "1:a:0"]
+            if subtitle_filter:
                 ffmpeg_command.extend(["-vf", subtitle_filter])
             ffmpeg_command.extend(["-c:v", "libx264", "-preset", "medium", "-crf", "19", "-pix_fmt", "yuv420p", "-c:a", "aac", "-b:a", "160k", "-movflags", "+faststart", "-shortest", partial_final.name])
             run(ffmpeg_command, cwd=job_dir, job_id=job_id)


### PR DESCRIPTION
## Summary

- add a POSIX launcher for macOS/Linux
- remove Windows-only Python and font path assumptions from the backend and rendering helpers
- add macOS browser discovery and fix URL-encoded project paths in the Remotion renderer
- document macOS setup, PyPI mirror usage, and Remotion macOS requirements

## Validation

- `python -m unittest discover -s tests -v` — 24 passed
- `cd web && npm test` — passed
- `cd video_renderer && npm run build` — passed
- Remotion 4.0.515 smoke render on macOS 26.6.2 — passed, 2-second MP4 exported

The original Remotion version `4.0.515` is preserved; no dependency downgrade is included.
